### PR TITLE
Error handling for invalid DOIs in cr_cn()

### DIFF
--- a/R/cr_cn.r
+++ b/R/cr_cn.r
@@ -65,7 +65,13 @@ cr_cn <- function(dois,
   }
 
   if(length(dois) > 1)
-    lapply(dois, cn)
+    lapply(dois, function(z) {
+      out = try(cn(z))
+      if("try-error" %in% class(out)) {
+        warning(paste0("Failure in resolving '", z, "'. See error detail in results."))
+      }
+      return(out) 
+    })
   else
     cn(dois)
 }


### PR DESCRIPTION
Now if some DOIs are invalid in the vector,
the error will be recorded as a `try-error` object
in the returned list, but the function will still
succeed (with a warning).
