### PR TITLE
More informative error message retained

### DIFF
--- a/R/cr_cn.r
+++ b/R/cr_cn.r
@@ -66,9 +66,10 @@ cr_cn <- function(dois,
 
   if(length(dois) > 1)
     lapply(dois, function(z) {
-      out = try(cn(z))
+      out = try(cn(z), silent=TRUE)
       if("try-error" %in% class(out)) {
         warning(paste0("Failure in resolving '", z, "'. See error detail in results."))
+        out = list(error=out, doi=z)
       }
       return(out) 
     })


### PR DESCRIPTION
Slight update.  Now a failed DOI lookup returns not just the error but also the text of the DOI that failed.  Also added silent=TRUE because the error message raised is redundant.
