### PR TITLE
DOI from failed call in cr_cn is retained.

### DIFF
--- a/R/cr_cn.r
+++ b/R/cr_cn.r
@@ -70,10 +70,10 @@ cr_cn <- function(dois,
 
   if(length(dois) > 1)
     lapply(dois, function(z) {
-      out = try(cn(z))
+      out = try(cn(z), silent=TRUE)
       if("try-error" %in% class(out)) {
         warning(paste0("Failure in resolving '", z, "'. See error detail in results."))
-        out <- out[[1]]
+        out <- list(doi=z, error=out[[1]])
       }
       return(out) 
     })


### PR DESCRIPTION
Now an error keeps a record of what DOI failed.
