### PR TITLE
added application/vnd.crossref.unixsd+xml as metadata content type

### DIFF
--- a/R/cr_cn.r
+++ b/R/cr_cn.r
@@ -4,7 +4,7 @@
 #'
 #' @param dois Search by a single DOI or many DOIs.
 #' @param format Name of the format. One of "rdf-xml", "turtle", "citeproc-json", "text", 
-#' "ris", "bibtex", "crossref-xml", "datacite-xml", or "bibentry"
+#' "ris", "bibtex", "crossref-xml", "datacite-xml","bibentry", or "crossref-tdm"
 #' @param style a CSL style (for text format only). See \code{\link{get_styles}} 
 #' for options. Default: apa. If there's a style that CrossRef doesn't support you'll get a 
 #' \code{(500) Internal Server Error}
@@ -52,7 +52,7 @@
 `cr_cn` <- function(dois, format = "text", style = 'apa', locale = "en-US", .progress="none", ...){
   format <- match.arg(format, c("rdf-xml", "turtle", "citeproc-json",
                                 "text", "ris", "bibtex", "crossref-xml",
-                                "datacite-xml", "bibentry"))
+                                "datacite-xml", "bibentry", "crossref-tdm"))
   cn <- function(doi, ...){
     url <- paste("http://dx.doi.org", doi, sep="/")
     pick <- c(
@@ -64,7 +64,8 @@
            "bibtex" = "application/x-bibtex",
            "crossref-xml" = "application/vnd.crossref.unixref+xml",
            "datacite-xml" = "application/vnd.datacite.datacite+xml",
-           "bibentry" = "application/x-bibtex")
+           "bibentry" = "application/x-bibtex",
+           "crossref-tdm" = "application/vnd.crossref.unixsd+xml")
     type <- pick[[format]]
     if(format == "text")
       type <- paste(type, "; style = ", style, "; locale = ", locale, sep="")
@@ -79,7 +80,8 @@
            "bibtex" = "text/plain",
            "crossref-xml" = "text/xml",
            "datacite-xml" = "text/xml",
-           "bibentry" = "text/plain")
+           "bibentry" = "text/plain",
+           "crossref-tdm" = "text/xml")
     parser <- select[[format]]
     out <- content(response, "parsed", parser, "UTF-8")
     if(format == "text")


### PR DESCRIPTION
Propose to add `application/vnd.crossref.unixsd+xml` as metadata content type to the `cr_cn` function. This format includes `crm-items` which provides further useful metadata elements on the article level like information on the publisher. It also allows to retrieve cited-by counts without passing an API key to CrossRef. 

Elements: http://www.crossref.org/help/schema_doc/crossref_query_output3.0/3_0.html#crm-item

Note, the content type is only documented as part of [CrossRef Text and Data Mining Services](http://tdmsupport.crossref.org/researchers/), but not listed in the [CrossRef and DataCite content negotiation documentation](http://www.crosscite.org/cn/).

Test Gist: https://gist.github.com/njahn82/cd51c45822b7ecfa8883#file-doccn-md
