### PR TITLE
fix error when passing a non-indexed doi to cr_works  

### DIFF
--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -69,7 +69,7 @@
     res <- lapply(res, "[[", "message")
     res <- lapply(res, parse_works)
     df <- rbind_all(res)
-    df$dois <- dois
+ #  df$dois <- dois
     list(meta=NULL, data=df, facets=NULL)
   } else { 
     tmp <- foo(dois)

--- a/tests/testthat/test_cr_works.R
+++ b/tests/testthat/test_cr_works.R
@@ -44,7 +44,7 @@ test_that("cr_works dimensions are correct", {
   
   expect_equal(NCOL(a$data), 21)
   expect_equal(NCOL(b$meta), 4)
-  expect_equal(NCOL(e$data), 21)
+  expect_equal(NCOL(e$data), 20)
   expect_equal(NCOL(h$facets$license), 2)
 })
 


### PR DESCRIPTION

I ran into a problem when passing a vector of dois to `cr_works()` and at least one DOI is not accessible through the CrossRef API. 


```r
require(devtools)
install_github("ropensci/rcrossref")

library(rcrossref)

x <- c("10.4172/2161-0398.S1-001", "10.1002/phy2.132")	

cr_works(x)
```

```
## Warning: 404: 10.4172/2161-0398.S1-001 not found
```

```
## Error: replacement has 2 rows, data has 1
```

Would it be ok for you to skip adding dois to be queried as column to the resulting data.frame?
