### PR TITLE
Provide contact information to Crossref

### DIFF
--- a/R/cr_fundref.r
+++ b/R/cr_fundref.r
@@ -81,10 +81,10 @@
 `cr_funders` <- function(dois = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL,  sample = NULL, sort = NULL, order = NULL,
   facet=FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", flq = NULL, ...) {
+  .progress="none", flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort,
-                    order, facet, cursor, flq)
+                    order, facet, cursor, flq, email)
   if (length(dois) > 1) {
     res <- llply(dois, fundref_GET, args = args, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
@@ -167,10 +167,10 @@
 `cr_funders_` <- function(dois = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL,  sample = NULL, sort = NULL, order = NULL,
   facet=FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", parse=FALSE, flq = NULL, ...) {
+  .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(dois) > 1) {
     llply(dois, fundref_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse, ...,

--- a/R/cr_fundref.r
+++ b/R/cr_fundref.r
@@ -84,9 +84,9 @@
   .progress="none", flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort,
-                    order, facet, cursor, flq, email)
+                    order, facet, cursor, flq)
   if (length(dois) > 1) {
-    res <- llply(dois, fundref_GET, args = args, works = works,
+    res <- llply(dois, fundref_GET, args = args, email = email, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
                  .progress = .progress)
     if (!is.null(cursor)) {
@@ -129,8 +129,8 @@
       }
     }
   } else {
-    res <- fundref_GET(dois, args = args, works = works, cursor = cursor,
-                       cursor_max = cursor_max, ...)
+    res <- fundref_GET(dois, args = args, email = email, works = works, cursor = cursor,
+                       cursor_max = cursor_max, email = email, ...)
     if (!is.null(cursor)) {
       res
     } else {
@@ -170,13 +170,13 @@
   .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(dois) > 1) {
-    llply(dois, fundref_GET_, args = args, works = works,
+    llply(dois, fundref_GET_, args = args, email = email, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse, ...,
           .progress = .progress)
   } else {
-    fundref_GET_(dois, args = args, works = works, cursor = cursor,
+    fundref_GET_(dois, args = args, email = email, works = works, cursor = cursor,
                 cursor_max = cursor_max, parse = parse, ...)
   }
 }
@@ -189,12 +189,12 @@ fundref_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = TRUE, ...)
     rr$GETcursor()
     rr$parse()
   } else {
-    cr_GET(path, args, todf = FALSE, ...)
+    cr_GET(path, args, email, todf = FALSE, ...)
   }
 }
 
@@ -207,7 +207,7 @@ fundref_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL,
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out

--- a/R/cr_journals.r
+++ b/R/cr_journals.r
@@ -88,10 +88,10 @@
     }
   }
   args <- prep_args(query, filter, offset, limit, sample,
-                    sort, order, facet, cursor, flq, email)
+                    sort, order, facet, cursor, flq)
 
   if (length(issn) > 1) {
-    res <- llply(issn, journal_GET, args = args, works = works,
+    res <- llply(issn, journal_GET, args = args, email = email, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
                  .progress = .progress)
     if (!is.null(cursor)) {
@@ -159,9 +159,9 @@
     }
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(issn) > 1) {
-    llply(issn, journal_GET_, args = args, works = works,
+    llply(issn, journal_GET_, args = args, email = email, works = works,
           cursor = cursor, cursor_max = cursor_max,
           parse = parse, ..., .progress = .progress)
   } else {
@@ -177,7 +177,7 @@ journal_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = TRUE, ...)
     rr$GETcursor()
     rr$parse()
@@ -195,7 +195,7 @@ journal_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL,
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out

--- a/R/cr_journals.r
+++ b/R/cr_journals.r
@@ -80,7 +80,7 @@
 `cr_journals` <- function(issn = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works=FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", flq = NULL, ...) {
+  .progress="none", flq = NULL, email = NULL, ...) {
 
   if (works) {
     if (is.null(issn)) {
@@ -88,7 +88,7 @@
     }
   }
   args <- prep_args(query, filter, offset, limit, sample,
-                    sort, order, facet, cursor, flq)
+                    sort, order, facet, cursor, flq, email)
 
   if (length(issn) > 1) {
     res <- llply(issn, journal_GET, args = args, works = works,
@@ -151,7 +151,7 @@
 `cr_journals_` <- function(issn = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works=FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", parse=FALSE, flq = NULL, ...) {
+  .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   if (works) {
     if (is.null(issn)) {
@@ -159,7 +159,7 @@
     }
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(issn) > 1) {
     llply(issn, journal_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max,

--- a/R/cr_members.r
+++ b/R/cr_members.r
@@ -65,10 +65,11 @@
 #' }
 `cr_members` <- function(member_ids = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE, works = FALSE,
-  cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, ...) {
+  cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, email = NULL, 
+  ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(member_ids) > 1) {
     res <- llply(member_ids, member_GET, args = args, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
@@ -127,10 +128,10 @@
 `cr_members_` <- function(member_ids = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet=FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", parse=FALSE, flq = NULL, ...) {
+  .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort,
-                    order, facet, cursor, flq)
+                    order, facet, cursor, flq, email)
   if (length(member_ids) > 1) {
     llply(member_ids, member_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse,

--- a/R/cr_members.r
+++ b/R/cr_members.r
@@ -69,9 +69,9 @@
   ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(member_ids) > 1) {
-    res <- llply(member_ids, member_GET, args = args, works = works,
+    res <- llply(member_ids, member_GET, args = args, email= email, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
                  .progress = .progress)
     if (!is.null(cursor)) {
@@ -99,7 +99,7 @@
     }
   } else if (length(member_ids) == 1) {
     tmp <- member_GET(member_ids, args = args, works = works,
-                      cursor = cursor, cursor_max = cursor_max, ...)
+                      cursor = cursor, cursor_max = cursor_max, email = email, ...)
     if (!is.null(cursor)) {
       tmp
     } else {
@@ -112,7 +112,7 @@
       }
     }
   } else {
-    tmp <- member_GET(NULL, args = args, works = works, ...)
+    tmp <- member_GET(NULL, args = args, email = email, works = works, ...)
     if (is.null(tmp$message)) {
       list(meta = NULL, data = NULL, facets = NULL)
     } else {
@@ -131,14 +131,15 @@
   .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort,
-                    order, facet, cursor, flq, email)
+                    order, facet, cursor, flq)
   if (length(member_ids) > 1) {
     llply(member_ids, member_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse,
-          .progress = .progress, ...)
+          .progress = .progress, email = email, ...)
   } else {
     member_GET_(member_ids, args = args, works = works,
-               cursor = cursor, cursor_max = cursor_max, parse = parse, ...)
+               cursor = cursor, cursor_max = cursor_max, parse = parse, 
+               email = email, ...)
   }
 }
 
@@ -151,7 +152,7 @@ member_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
 
   if (!is.null(cursor) && works) {
     rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
-                        should_parse = TRUE, ...)
+                        should_parse = TRUE, email = email, ...)
     rr$GETcursor()
     rr$parse()
   } else {
@@ -160,7 +161,7 @@ member_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
 }
 
 member_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL,
-                        parse, ...) {
+                        parse, email, ...) {
   path <- if (!is.null(x)) {
     if (works) sprintf("members/%s/works", x) else sprintf("members/%s", x)
   } else {
@@ -168,7 +169,7 @@ member_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL,
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out

--- a/R/cr_prefixes.r
+++ b/R/cr_prefixes.r
@@ -83,9 +83,9 @@
   flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(prefixes) > 1) {
-    res <- llply(prefixes, prefixes_GET, args = args, works = works,
+    res <- llply(prefixes, prefixes_GET, args = args, email = email, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
                  .progress = .progress)
     if (!is.null(cursor)) {
@@ -116,7 +116,7 @@
     }
   } else {
     tmp <- prefixes_GET(prefixes, args, works = works, cursor = cursor,
-                        cursor_max = cursor_max, ...)
+                        cursor_max = cursor_max, email, ...)
     if (!is.null(cursor)) {
       tmp
     } else {
@@ -143,9 +143,9 @@
   email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(prefixes) > 1) {
-    llply(prefixes, prefixes_GET_, args = args, works = works,
+    llply(prefixes, prefixes_GET_, args = args, email = email, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse,
           ..., .progress = .progress)
   } else {
@@ -154,10 +154,10 @@
   }
 }
 
-prefixes_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
+prefixes_GET <- function(x, args, email, works, cursor = NULL, cursor_max = NULL, ...){
   path <- if (works) sprintf("prefixes/%s/works", x) else sprintf("prefixes/%s", x)
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = TRUE, ...)
     rr$GETcursor()
     rr$parse()
@@ -166,15 +166,15 @@ prefixes_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
   }
 }
 
-prefixes_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL, parse, ...){
+prefixes_GET_ <- function(x, args, email, works, cursor = NULL, cursor_max = NULL, parse, ...){
   path <- if (works) sprintf("prefixes/%s/works", x) else sprintf("prefixes/%s", x)
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out
   } else {
-    cr_GET(path, args, todf = FALSE, parse = parse, ...)
+    cr_GET(path, args, email, todf = FALSE, parse = parse, ...)
   }
 }
 

--- a/R/cr_prefixes.r
+++ b/R/cr_prefixes.r
@@ -80,10 +80,10 @@
 `cr_prefixes` <- function(prefixes, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
   works = FALSE, cursor = NULL, cursor_max = 5000, .progress="none",
-  flq = NULL, ...) {
+  flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(prefixes) > 1) {
     res <- llply(prefixes, prefixes_GET, args = args, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
@@ -139,10 +139,11 @@
 #' @rdname cr_prefixes
 `cr_prefixes_` <- function(prefixes, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE, works = FALSE,
-  cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, ...) {
+  cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, 
+  email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(prefixes) > 1) {
     llply(prefixes, prefixes_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse,

--- a/R/cr_types.R
+++ b/R/cr_types.R
@@ -62,10 +62,10 @@
 `cr_types` <- function(types = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", flq = NULL, ...) {
+  .progress="none", flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(types) > 1) {
     res <- llply(types, types_GET, args = args, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
@@ -134,10 +134,10 @@
 `cr_types_` <- function(types = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet=FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress="none", parse=FALSE, flq = NULL, ...) {
+  .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
+                    facet, cursor, flq, email)
   if (length(types) > 1) {
     llply(types, types_GET_, args = args, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse, ...,

--- a/R/cr_types.R
+++ b/R/cr_types.R
@@ -65,9 +65,9 @@
   .progress="none", flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(types) > 1) {
-    res <- llply(types, types_GET, args = args, works = works,
+    res <- llply(types, types_GET, args = args, email = email, works = works,
                  cursor = cursor, cursor_max = cursor_max, ...,
                  .progress = .progress)
     if (!is.null(cursor)) {
@@ -137,9 +137,9 @@
   .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
 
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   if (length(types) > 1) {
-    llply(types, types_GET_, args = args, works = works,
+    llply(types, types_GET_, args = args, email = email, works = works,
           cursor = cursor, cursor_max = cursor_max, parse = parse, ...,
           .progress = .progress)
   } else {
@@ -156,7 +156,7 @@ types_GET <- function(x, args, works, cursor = NULL, cursor_max = NULL, ...){
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = TRUE, ...)
     rr$GETcursor()
     rr$parse()
@@ -174,7 +174,7 @@ types_GET_ <- function(x, args, works, cursor = NULL, cursor_max = NULL,
   }
 
   if (!is.null(cursor) && works) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -114,15 +114,15 @@
 #' }
 
 `cr_works` <- function(dois = NULL, query = NULL, filter = NULL, offset = NULL,
-  limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
-  cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, ...) {
-
+                       limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
+                       cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, email = NULL, ...) {
+  
   if (cursor_max != as.integer(cursor_max)) {
     stop("cursor_max must be an integer", call. = FALSE)
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
-
+                    facet, cursor, flq, email)
+  
   if (length(dois) > 1) {
     res <- llply(dois, cr_get_cursor, args = args, cursor = cursor,
                  cursor_max = cursor_max, .progress = .progress, ...)
@@ -157,15 +157,15 @@
 #' @export
 #' @rdname cr_works
 `cr_works_` <- function(dois = NULL, query = NULL, filter = NULL, offset = NULL,
-  limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
-  cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, ...) {
-
+                        limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
+                        cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
+  
   if (cursor_max != as.integer(cursor_max)) {
     stop("cursor_max must be an integer", call. = FALSE)
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq)
-
+                    facet, cursor, flq, email)
+  
   if (length(dois) > 1) {
     llply(dois, cr_get_cursor_, args = args, cursor = cursor,
           cursor_max = cursor_max, parse = parse, .progress = .progress, ...)
@@ -267,7 +267,7 @@ parse_works <- function(zzz){
       volume = list(y[[which]]),
       abstract = list(y[[which]])
     )
-
+    
     res <- if (is.null(res) || length(res) == 0) NA else res
     if (length(res[[1]]) > 1) {
       names(res[[1]]) <- paste(which, names(res[[1]]), sep = "_")
@@ -277,7 +277,7 @@ parse_works <- function(zzz){
       res
     }
   }
-
+  
   if (is.null(zzz)) {
     NULL
   } else if (all(is.na(zzz))) {

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -114,8 +114,9 @@
 #' }
 
 `cr_works` <- function(dois = NULL, query = NULL, filter = NULL, offset = NULL,
-                       limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
-                       cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, email = NULL, ...) {
+  limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
+  cursor = NULL, cursor_max = 5000, .progress="none", flq = NULL, email = NULL, 
+  ...) {
   
   if (cursor_max != as.integer(cursor_max)) {
     stop("cursor_max must be an integer", call. = FALSE)
@@ -157,8 +158,9 @@
 #' @export
 #' @rdname cr_works
 `cr_works_` <- function(dois = NULL, query = NULL, filter = NULL, offset = NULL,
-                        limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
-                        cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, email = NULL, ...) {
+  limit = NULL, sample = NULL, sort = NULL, order = NULL, facet=FALSE,
+  cursor = NULL, cursor_max = 5000, .progress="none", parse=FALSE, flq = NULL, 
+  email = NULL, ...) {
   
   if (cursor_max != as.integer(cursor_max)) {
     stop("cursor_max must be an integer", call. = FALSE)

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -122,10 +122,10 @@
     stop("cursor_max must be an integer", call. = FALSE)
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   
   if (length(dois) > 1) {
-    res <- llply(dois, cr_get_cursor, args = args, cursor = cursor,
+    res <- llply(dois, cr_get_cursor, args = args, email = email, cursor = cursor,
                  cursor_max = cursor_max, .progress = .progress, ...)
     res <- lapply(res, "[[", "message")
     res <- lapply(res, parse_works)
@@ -138,7 +138,7 @@
     df <- df[!df$DOI == "", ]
     list(meta = NULL, data = df, facets = NULL)
   } else {
-    tmp <- cr_get_cursor(dois, args = args, cursor = cursor,
+    tmp <- cr_get_cursor(dois, args = args, email = email, cursor = cursor,
                          cursor_max = cursor_max, ...)
     if (is.null(dois)) {
       if (!is.null(cursor) || is.null(tmp$message)) {
@@ -166,13 +166,13 @@
     stop("cursor_max must be an integer", call. = FALSE)
   }
   args <- prep_args(query, filter, offset, limit, sample, sort, order,
-                    facet, cursor, flq, email)
+                    facet, cursor, flq)
   
   if (length(dois) > 1) {
-    llply(dois, cr_get_cursor_, args = args, cursor = cursor,
+    llply(dois, cr_get_cursor_, args = args, email = email, cursor = cursor,
           cursor_max = cursor_max, parse = parse, .progress = .progress, ...)
   } else {
-    cr_get_cursor_(dois, args = args, cursor = cursor,
+    cr_get_cursor_(dois, args = args, email = email, cursor = cursor,
                    cursor_max = cursor_max, parse = parse, ...)
   }
 }
@@ -180,7 +180,7 @@
 cr_get_cursor <- function(x, args, cursor, cursor_max, ...) {
   path <- if (!is.null(x)) sprintf("works/%s", x) else "works"
   if (!is.null(cursor)) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = TRUE, ...)
     rr$GETcursor()
     rr$parse()
@@ -192,7 +192,7 @@ cr_get_cursor <- function(x, args, cursor, cursor_max, ...) {
 cr_get_cursor_ <- function(x, args, cursor, cursor_max, parse, ...) {
   path <- if (!is.null(x)) sprintf("works/%s", x) else "works"
   if (!is.null(cursor)) {
-    rr <- Requestor$new(path = path, args = args, cursor_max = cursor_max,
+    rr <- Requestor$new(path = path, args = args, email = email, cursor_max = cursor_max,
                         should_parse = parse, ...)
     rr$GETcursor()
     rr$cursor_out

--- a/R/rcrossref-package.R
+++ b/R/rcrossref-package.R
@@ -66,6 +66,26 @@
 #' citations will be added to a file called `crossref.bib`. New citations
 #' will be appended to that file. Addin authored by Hao Zhu
 #' <https://github.com/haozhu233>
+#' 
+#' @section Be nice and share your email with Crossref:
+#' The Crossref team encourage requests with appropriate contact information 
+#' and will forward you to a dedicated API cluster for improved performance when 
+#' you share your email address with them.
+#' <https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service>
+#' 
+#' To pass your email address to Crossref via this client, simply store it 
+#' as environment variable in `.Renviron` like this:
+#' 
+#' 1. Open file:
+#' `file.edit("~/.Renviron")`
+#' 
+#' 2. Add email address to be shared with Crossref
+#' `crossref_email = name@example.com`
+#' 
+#' 3. Save the file and restart your R session
+#' 
+#' Don't wanna share your email any longer? Simply delete it from 
+#' `~/.Renviron`
 #'
 #' @importFrom methods as
 #' @importFrom utils modifyList packageVersion

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -12,23 +12,23 @@ asl <- function(z) {
   }
 }
 
-rcrossref_ua <- function(email) {
+rcrossref_ua <- function() {
   versions <- c(paste0("r-curl/", utils::packageVersion("curl")),
                 paste0("crul/", utils::packageVersion("crul")),
                 sprintf("rOpenSci(rcrossref/%s)", 
                         utils::packageVersion("rcrossref")),
-                mailto(email))
+                get_email())
   paste0(versions, collapse = " ")
 }
 
-cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE, email, ...) {
+cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE, 
+                   ...) {
   url <- sprintf("https://api.crossref.org/%s", endpoint)
   cli <- crul::HttpClient$new(
     url = url,
-#    opts = list( verbose = TRUE ),
     headers = list(
-      `User-Agent` = rcrossref_ua(email),
-      `X-USER-AGENT` = rcrossref_ua(email)
+      `User-Agent` = rcrossref_ua(),
+      `X-USER-AGENT` = rcrossref_ua()
     )
   )
   if (length(args) == 0) {
@@ -157,7 +157,19 @@ prep_args <- function(query, filter, offset, limit, sample, sort,
 
 `%||%` <- function(x, y) if (is.null(x) || length(x) == 0) y else x
 
-#' Email checker for Crossref API
+
+#' Share email with Crossref in `.Renviron`
+#' 
+#' @noRd
+get_email <- function() {
+  email <- Sys.getenv("crossref_email")
+  if (identical(email, "")) {
+    NULL
+  }
+  paste0("(mailto:", val_email(email), ")")
+}
+
+#' Email checker
 #'
 #' It implementents the following regex stackoverflow solution
 #' http://stackoverflow.com/a/25077140
@@ -166,9 +178,8 @@ prep_args <- function(query, filter, offset, limit, sample, sort,
 #'
 #' @noRd
 val_email <- function(email) {
-  if(!is.null(email))
-    if (!grepl(email_regex(), email))
-    stop("Email address seems not properly formatted - Please check!",
+  if (!grepl(email_regex(), email))
+    stop("Email address seems not properly formatted - Please check your .Renviron!",
          call. = FALSE)
   return(email)
 }
@@ -182,13 +193,3 @@ email_regex <-
   function()
     "^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$"
 
-#' Make email string for user header
-#' @param email email address
-#' 
-#' @noRd
-mailto <- function(email) {
-  if(!is.null(email))
-    paste0("(mailto:", val_email(email), ")")
-  else
-    NULL
-}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -133,10 +133,11 @@ field_query_handler <- function(x) {
 }
 
 prep_args <- function(query, filter, offset, limit, sample, sort, 
-                      order, facet, cursor, flq) {
+                      order, facet, cursor, flq, email) {
   check_limit(limit)
   check_number(offset)
   check_number(sample)
+  val_email(email)
   filter <- filter_handler(filter)
   flq <- field_query_handler(flq)
   stopifnot(class(facet) %in% c('logical', 'character'))
@@ -147,10 +148,35 @@ prep_args <- function(query, filter, offset, limit, sample, sort,
     c(
       list(query = query, filter = filter, offset = offset, rows = limit,
            sample = sample, sort = sort, order = order, facet = facet,
-           cursor = cursor),
+           cursor = cursor, mailto = email),
       flq
     )
   )
 }
 
 `%||%` <- function(x, y) if (is.null(x) || length(x) == 0) y else x
+
+#' Email checker for Crossref API
+#'
+#' It implementents the following regex stackoverflow solution
+#' http://stackoverflow.com/a/25077140
+#'
+#' @param email email address (character string)
+#'
+#' @noRd
+val_email <- function(email) {
+  if(!is.null(email))
+    if (!grepl(email_regex(), email))
+    stop("Email address seems not properly formatted - Please check!",
+         call. = FALSE)
+  return(email)
+}
+
+#' Email regex
+#'
+#' From \url{http://stackoverflow.com/a/25077140}
+#'
+#' @noRd
+email_regex <-
+  function()
+    "^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$"

--- a/man-roxygen/args.R
+++ b/man-roxygen/args.R
@@ -11,3 +11,6 @@
 #' @param sort (character) Field to sort on, one of score, relevance, updated,
 #' deposited, indexed, or published.
 #' @param order (character) Sort order, one of 'asc' or 'desc'
+#' @param email (character) Provide contact information to Crossref, so that
+#' they can contact you if something goes wrong. Crossref awards contact info
+#' with a a special pool of API machines.

--- a/man/cr_funders.Rd
+++ b/man/cr_funders.Rd
@@ -8,12 +8,12 @@
 cr_funders(dois = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", flq = NULL, ...)
+  .progress = "none", flq = NULL, email = NULL, ...)
 
 cr_funders_(dois = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", parse = FALSE, flq = NULL, ...)
+  .progress = "none", parse = FALSE, flq = NULL, email = NULL, ...)
 }
 \arguments{
 \item{dois}{Search by a single DOI or many DOIs.}
@@ -74,6 +74,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/cr_journals.Rd
+++ b/man/cr_journals.Rd
@@ -8,12 +8,12 @@
 cr_journals(issn = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", flq = NULL, ...)
+  .progress = "none", flq = NULL, email = NULL, ...)
 
 cr_journals_(issn = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", parse = FALSE, flq = NULL, ...)
+  .progress = "none", parse = FALSE, flq = NULL, email = NULL, ...)
 }
 \arguments{
 \item{issn}{(character) One or more ISSN's. Format: XXXX-XXXX.}
@@ -74,6 +74,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/cr_members.Rd
+++ b/man/cr_members.Rd
@@ -8,12 +8,13 @@
 cr_members(member_ids = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL,
   order = NULL, facet = FALSE, works = FALSE, cursor = NULL,
-  cursor_max = 5000, .progress = "none", flq = NULL, ...)
+  cursor_max = 5000, .progress = "none", flq = NULL, email = NULL, ...)
 
 cr_members_(member_ids = NULL, query = NULL, filter = NULL,
   offset = NULL, limit = NULL, sample = NULL, sort = NULL,
   order = NULL, facet = FALSE, works = FALSE, cursor = NULL,
-  cursor_max = 5000, .progress = "none", parse = FALSE, flq = NULL, ...)
+  cursor_max = 5000, .progress = "none", parse = FALSE, flq = NULL,
+  email = NULL, ...)
 }
 \arguments{
 \item{member_ids}{One or more member ids. See examples. ALternatively,
@@ -75,6 +76,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/cr_prefixes.Rd
+++ b/man/cr_prefixes.Rd
@@ -8,12 +8,12 @@
 cr_prefixes(prefixes, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", flq = NULL, ...)
+  .progress = "none", flq = NULL, email = NULL, ...)
 
 cr_prefixes_(prefixes, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", parse = FALSE, flq = NULL, ...)
+  .progress = "none", parse = FALSE, flq = NULL, email = NULL, ...)
 }
 \arguments{
 \item{prefixes}{(character) Publisher prefixes, one or more in a vector or
@@ -75,6 +75,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/cr_types.Rd
+++ b/man/cr_types.Rd
@@ -8,12 +8,12 @@
 cr_types(types = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", flq = NULL, ...)
+  .progress = "none", flq = NULL, email = NULL, ...)
 
 cr_types_(types = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, works = FALSE, cursor = NULL, cursor_max = 5000,
-  .progress = "none", parse = FALSE, flq = NULL, ...)
+  .progress = "none", parse = FALSE, flq = NULL, email = NULL, ...)
 }
 \arguments{
 \item{types}{(character) Type identifier, e.g., journal}
@@ -74,6 +74,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/cr_works.Rd
+++ b/man/cr_works.Rd
@@ -8,12 +8,12 @@
 cr_works(dois = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, cursor = NULL, cursor_max = 5000, .progress = "none",
-  flq = NULL, ...)
+  flq = NULL, email = NULL, ...)
 
 cr_works_(dois = NULL, query = NULL, filter = NULL, offset = NULL,
   limit = NULL, sample = NULL, sort = NULL, order = NULL,
   facet = FALSE, cursor = NULL, cursor_max = 5000, .progress = "none",
-  parse = FALSE, flq = NULL, ...)
+  parse = FALSE, flq = NULL, email = NULL, ...)
 }
 \arguments{
 \item{dois}{Search by a single DOI or many DOIs.}
@@ -72,6 +72,10 @@ field query parameters are:
  \item query.contributor    - Query author, editor, chair and translator 
  first and given names
 }}
+
+\item{email}{(character) Provide contact information to Crossref, so that
+they can contact you if something goes wrong. Crossref awards contact info
+with a a special pool of API machines.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 

--- a/man/rcrossref-package.Rd
+++ b/man/rcrossref-package.Rd
@@ -89,4 +89,25 @@ will be appended to that file. Addin authored by Hao Zhu
 \url{https://github.com/haozhu233}
 }
 
+\section{Be nice and share your email with Crossref}{
+
+The Crossref team encourage requests with appropriate contact information
+and will forward you to a dedicated API cluster for improved performance when
+you share your email address with them.
+\url{https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service}
+
+To pass your email address to Crossref via this client, simply store it
+as environment variable in \code{.Renviron} like this:
+\enumerate{
+\item Open file:
+\code{file.edit("~/.Renviron")}
+\item Add email address to be shared with Crossref
+\code{crossref_email = name@example.com}
+\item Save the file and restart your R session
+}
+
+Don't wanna share your email any longer? Simply delete it from
+\code{~/.Renviron}
+}
+
 \keyword{package}

--- a/tests/testthat/test_cr_funders.R
+++ b/tests/testthat/test_cr_funders.R
@@ -8,6 +8,9 @@ test_that("cr_funders returns", {
                                           '10.13039/100000015')))
   b <- suppressWarnings(cr_funders(dois='10.13039/100000001', 
                                    works=TRUE, limit=5))
+  c <- suppressWarnings(cr_funders(dois=c('10.13039/100000001',
+                                          '10.13039/100000015'),
+                                   email = "name@example.com"))
 
   # correct clases
   expect_is(suppressWarnings(cr_funders(query="NSF", limit=1)), "list")
@@ -17,10 +20,16 @@ test_that("cr_funders returns", {
 
   expect_is(b, "list")
   expect_is(b$data, "tbl_df")
+  
+  
+  expect_is(c, "list")
+  expect_is(c[[1]]$data, "data.frame")
+  expect_is(c[[1]]$descendants, "character")
 
   # dimensions are correct
   expect_equal(length(a), 2)
   expect_equal(length(b), 3)
+  expect_equal(length(c), 2)
 })
 
 test_that("cr_funders facet works", {

--- a/tests/testthat/test_cr_journals.R
+++ b/tests/testthat/test_cr_journals.R
@@ -21,6 +21,11 @@ test_that("cr_journals metadata works correctly", {
   expect_equal(cr_journals(query="peerj", limit=4)$meta$items_per_page, 4)
 })
 
+test_that("cr_journals email param works correctly", {
+  skip_on_cran()
+  
+  expect_is(cr_journals(email = "name@example.com"), "list")
+})
 test_that("cr_journals fails correctly", {
   skip_on_cran()
 

--- a/tests/testthat/test_cr_members.R
+++ b/tests/testthat/test_cr_members.R
@@ -9,6 +9,7 @@ test_that("cr_members returns", {
   c <- cr_members(member_ids=c(10,98,45,1,9))
   d <- cr_members(member_ids=c(10,98,45,1,9), works=TRUE)
   e <- cr_members(query='ecology')
+  f <- cr_members(member_ids=98, email = "name@example.com")
 
   # correct class
   expect_is(a, "list")
@@ -26,12 +27,18 @@ test_that("cr_members returns", {
   expect_is(d, "list")
   expect_is(e, "list")
   expect_equal(e$facets, NULL)
+  
+  expect_is(a, "list")
+  expect_null(f$meta)
+  expect_is(f$data, "data.frame")
+  expect_is(f$datf$primary_name, "character")
 
   # dimensions are correct
   expect_equal(length(a), 3)
   expect_equal(length(b), 3)
   expect_equal(length(e), 3)
   expect_equal(length(d$facets), 0)
+  expect_equal(length(f), 3)
 })
 
 test_that("cr_members fails correctly", {

--- a/tests/testthat/test_cr_prefixes.R
+++ b/tests/testthat/test_cr_prefixes.R
@@ -42,6 +42,19 @@ test_that("cr_prefixes facet works correctly", {
   expect_is(aa$facets$orcid, 'data.frame')
 })
 
+test_that("cr_prefixes email param works correctly", {
+  skip_on_cran()
+  
+  aa <- cr_prefixes(prefixes="10.1016", works=TRUE, facet=TRUE, limit = 10,
+                    email = "name@example.com")
+  
+  expect_is(aa, "list")
+  expect_named(aa, c('meta', 'data', 'facets'))
+  expect_is(aa$facets, 'list')
+  expect_is(aa$facets$affiliation, 'data.frame')
+  expect_is(aa$facets$orcid, 'data.frame')
+})
+
 test_that("cr_prefixes fails correctly", {
   skip_on_cran()
 

--- a/tests/testthat/test_cr_types.R
+++ b/tests/testthat/test_cr_types.R
@@ -48,6 +48,17 @@ test_that("cr_types facet works correctly", {
   expect_is(aa$facets$orcid, 'data.frame')
 })
 
+test_that("cr_types email param works correctly", {
+  skip_on_cran()
+  
+  aa <- cr_types("monograph", works=TRUE, facet=TRUE, limit = 0, 
+                 email = "name@example.com")
+  expect_is(aa, "list")
+  expect_named(aa, c('meta', 'data', 'facets'))
+  expect_is(aa$facets, 'list')
+  expect_is(aa$facets$affiliation, 'data.frame')
+  expect_is(aa$facets$orcid, 'data.frame')
+})
 test_that("cr_types fails correctly", {
   skip_on_cran()
 

--- a/tests/testthat/test_cr_works.R
+++ b/tests/testthat/test_cr_works.R
@@ -13,6 +13,7 @@ test_that("cr_works returns", {
   g <- cr_works(sample=1)
   h <- cr_works(query="NSF", facet=TRUE)
   i <- suppressWarnings(cr_works(dois=c('blblbl', '10.1038/nnano.2014.279')))
+  j <- cr_works(query="NSF", email = "name@example.com")
 
   # correct class
   expect_is(a, "list")
@@ -24,12 +25,19 @@ test_that("cr_works returns", {
   expect_is(g, "list")
   expect_is(h, "list")
   expect_is(i, "list")
+  expect_is(j, "list")
 
   expect_is(a$meta, "data.frame")
   expect_is(a$data, "data.frame")
   expect_is(a$data, "tbl_df")
   expect_is(a$data$URL, "character")
   expect_equal(a$facets, NULL)
+  
+  expect_is(j$meta, "data.frame")
+  expect_is(j$data, "data.frame")
+  expect_is(j$data, "tbl_df")
+  expect_is(j$datj$URL, "character")
+  expect_equal(j$facets, NULL)
 
   expect_is(h, "list")
   expect_is(h$meta, "data.frame")
@@ -51,6 +59,7 @@ test_that("cr_works returns", {
   expect_equal(length(g), 3)
   expect_equal(length(h), 3)
   expect_equal(length(i), 3)
+  expect_equal(length(j), 3)
 })
 
 test_that("cr_works fails correctly", {
@@ -153,6 +162,12 @@ test_that("cr_works - parses affiliation inside authors correctly", {
   aa <- cr_works(doi)
   expect_true(any(grepl("author", names(aa$data))))
   expect_named(aa$data$author[[1]], c("given", "family", "affiliation.name"))
+})
+
+test_that("cr_works - email is correctly validated", {
+  skip_on_cran()
+  
+  expect_error(cr_works("10.1016/j.ffa.2015.10.008", email = "nj@g-t.c"))
 })
 
 Sys.sleep(2)


### PR DESCRIPTION
Crossref has recently begun to encourage API calls that have contact information. API users who send email together with the API request will be directed to a special pool of API machines.

https://github.com/CrossRef/rest-api-doc#etiquette

In this pull request, I added email as an optional parameter, and included an email validation function. Hope, I caught all relevant calls.
