### PR TITLE
Share contact infos with Crossref

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ addons:
     packages:
       - poppler-utils
 
-install:
+before_install:
   - mkdir -p ~/Rlib
   - echo 'crossref_email = name@example.com' > .Renviron
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,6 @@ addons:
     packages:
       - poppler-utils
 
-before_install:
-  - mkdir -p ~/Rlib
-  - echo 'crossref_email = name@example.com' > .Renviron
-
 r_github_packages:
   - jimhester/covr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,11 @@ addons:
     packages:
       - poppler-utils
 
+install:
+  - mkdir -p ~/Rlib
+  - echo 'crossref_email = name@example.com' > .Renviron
+  - echo 'options(repos = "http://cran.rstudio.com")' > .Rprofile
+  
 r_github_packages:
   - jimhester/covr
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,7 @@ addons:
 install:
   - mkdir -p ~/Rlib
   - echo 'crossref_email = name@example.com' > .Renviron
-  - echo 'options(repos = "http://cran.rstudio.com")' > .Rprofile
-  
+
 r_github_packages:
   - jimhester/covr
 

--- a/R/rcrossref-package.R
+++ b/R/rcrossref-package.R
@@ -66,6 +66,26 @@
 #' citations will be added to a file called `crossref.bib`. New citations
 #' will be appended to that file. Addin authored by Hao Zhu
 #' <https://github.com/haozhu233>
+#' 
+#' @section Be nice and share your email with Crossref:
+#' The Crossref team encourage requests with appropriate contact information 
+#' and will forward you to a dedicated API cluster for improved performance when 
+#' you share your email address with them.
+#' <https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service>
+#' 
+#' To pass your email address to Crossref via this client, simply store it 
+#' as environment variable in `.Renviron` like this:
+#' 
+#' 1. Open file:
+#' `file.edit("~/.Renviron")`
+#' 
+#' 2. Add email address to be shared with Crossref
+#' `crossref_email = name@example.com`
+#' 
+#' 3. Save the file and restart your R session
+#' 
+#' Don't wanna share your email any longer? Simply delete it from 
+#' `~/.Renviron`
 #'
 #' @importFrom methods as
 #' @importFrom utils modifyList packageVersion

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,7 +26,6 @@ cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE
   url <- sprintf("https://api.crossref.org/%s", endpoint)
   cli <- crul::HttpClient$new(
     url = url,
-    opts = list(verbose = TRUE),
     headers = list(
       `User-Agent` = rcrossref_ua(),
       `X-USER-AGENT` = rcrossref_ua()

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -26,6 +26,7 @@ cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE
   url <- sprintf("https://api.crossref.org/%s", endpoint)
   cli <- crul::HttpClient$new(
     url = url,
+    opts = list(verbose = TRUE),
     headers = list(
       `User-Agent` = rcrossref_ua(),
       `X-USER-AGENT` = rcrossref_ua()
@@ -165,8 +166,9 @@ get_email <- function() {
   email <- Sys.getenv("crossref_email")
   if (identical(email, "")) {
     NULL
-  }
+  } else {
   paste0("(mailto:", val_email(email), ")")
+  }
 }
 
 #' Email checker

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,14 +16,17 @@ rcrossref_ua <- function() {
   versions <- c(paste0("r-curl/", utils::packageVersion("curl")),
                 paste0("crul/", utils::packageVersion("crul")),
                 sprintf("rOpenSci(rcrossref/%s)", 
-                        utils::packageVersion("rcrossref")))
+                        utils::packageVersion("rcrossref")),
+                get_email())
   paste0(versions, collapse = " ")
 }
 
-cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE, ...) {
+cr_GET <- function(endpoint, args, todf = TRUE, on_error = warning, parse = TRUE, 
+                   ...) {
   url <- sprintf("https://api.crossref.org/%s", endpoint)
   cli <- crul::HttpClient$new(
     url = url,
+    opts = list(verbose = TRUE),
     headers = list(
       `User-Agent` = rcrossref_ua(),
       `X-USER-AGENT` = rcrossref_ua()
@@ -154,3 +157,40 @@ prep_args <- function(query, filter, offset, limit, sample, sort,
 }
 
 `%||%` <- function(x, y) if (is.null(x) || length(x) == 0) y else x
+
+
+#' Share email with Crossref in `.Renviron`
+#' 
+#' @noRd
+get_email <- function() {
+  email <- Sys.getenv("crossref_email")
+  if (identical(email, "")) {
+    NULL
+  }
+  paste0("(mailto:", val_email(email), ")")
+}
+
+#' Email checker
+#'
+#' It implementents the following regex stackoverflow solution
+#' http://stackoverflow.com/a/25077140
+#'
+#' @param email email address (character string)
+#'
+#' @noRd
+val_email <- function(email) {
+  if (!grepl(email_regex(), email))
+    stop("Email address seems not properly formatted - Please check your .Renviron!",
+         call. = FALSE)
+  return(email)
+}
+
+#' Email regex
+#'
+#' From \url{http://stackoverflow.com/a/25077140}
+#'
+#' @noRd
+email_regex <-
+  function()
+    "^[_a-z0-9-]+(\\.[_a-z0-9-]+)*@[a-z0-9-]+(\\.[a-z0-9-]+)*(\\.[a-z]{2,4})$"
+

--- a/man/rcrossref-package.Rd
+++ b/man/rcrossref-package.Rd
@@ -89,4 +89,25 @@ will be appended to that file. Addin authored by Hao Zhu
 \url{https://github.com/haozhu233}
 }
 
+\section{Be nice and share your email with Crossref}{
+
+The Crossref team encourage requests with appropriate contact information
+and will forward you to a dedicated API cluster for improved performance when
+you share your email address with them.
+\url{https://github.com/CrossRef/rest-api-doc#good-manners--more-reliable-service}
+
+To pass your email address to Crossref via this client, simply store it
+as environment variable in \code{.Renviron} like this:
+\enumerate{
+\item Open file:
+\code{file.edit("~/.Renviron")}
+\item Add email address to be shared with Crossref
+\code{crossref_email = name@example.com}
+\item Save the file and restart your R session
+}
+
+Don't wanna share your email any longer? Simply delete it from
+\code{~/.Renviron}
+}
+
 \keyword{package}

--- a/tests/testthat/test_cr_agency.R
+++ b/tests/testthat/test_cr_agency.R
@@ -19,4 +19,26 @@ test_that("cr_ageny fails correctly", {
   expect_error(cr_agency(dois = cr_r(3), timeout_ms = 1))
 })
 
+test_that("cr_agency - email works", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "name@example.com")
+  expect_is(cr_agency(dois = '10.1038/jid.2009.428'), "list")
+})
+
+
+test_that("cr_agency - email is validated", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "name@example")
+  expect_error(cr_agency(dois = '10.1038/jid.2009.428'))
+})
+
+test_that("cr_agency - email NULL works", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "")
+  expect_is(cr_agency(dois = '10.1038/jid.2009.428'), "list")
+})
+
 Sys.sleep(2)

--- a/tests/testthat/test_cr_funders.R
+++ b/tests/testthat/test_cr_funders.R
@@ -44,5 +44,27 @@ test_that("cr_funders fails correctly", {
                "Resource not found")
 })
 
+test_that("cr_works - email works", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "name@example.com")
+  expect_is(cr_funders(dois=c('10.13039/100000001')), "list")
+})
+
+
+test_that("cr_funders - email is validated", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "name@example")
+  expect_error(cr_funders(dois=c('10.13039/100000001')))
+})
+
+test_that("cr_funders - email NULL works", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "")
+  expect_is(cr_funders(dois=c('10.13039/100000001')), "list")
+})
+
 Sys.sleep(2)
 

--- a/tests/testthat/test_cr_works.R
+++ b/tests/testthat/test_cr_works.R
@@ -155,5 +155,28 @@ test_that("cr_works - parses affiliation inside authors correctly", {
   expect_named(aa$data$author[[1]], c("given", "family", "affiliation.name"))
 })
 
+test_that("cr_works - email works", {
+          skip_on_cran()
+  
+          Sys.setenv("crossref_email" = "name@example.com")
+          a <- cr_works(query="NSF")
+          expect_is(a, "list")
+})
+
+test_that("cr_works - email is validated", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "name@example")
+  expect_error(cr_works(query="NSF"))
+})
+
+test_that("cr_works - email NULL works", {
+  skip_on_cran()
+  
+  Sys.setenv("crossref_email" = "")
+  a <- cr_works(query="NSF")
+  expect_is(a, "list")
+})
+
 Sys.sleep(2)
 


### PR DESCRIPTION
Following #144 this stores the email address in `.Renviron` and shares it with Crossref via the user agent