### PR TITLE
Note that dois and query cannot both be set

### DIFF
--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -2,7 +2,7 @@
 #'
 #' @export
 #' @family crossref
-#' @param dois Search by a single DOI or many DOIs.
+#' @param dois Search by a single DOI or many DOIs.  Note that using this parameter at the same time as the `query` or `flq` parameter will result in an error.
 #' @template args
 #' @template moreargs
 #' @template cursor_args

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -2,7 +2,7 @@
 #'
 #' @export
 #' @family crossref
-#' @param dois Search by a single DOI or many DOIs.  Note that using this parameter at the same time as the `query` or `flq` parameter will result in an error.
+#' @param dois Search by a single DOI or many DOIs.  Note that using this parameter at the same time as the `query`, `limit`, `select` or `flq` parameter will result in an error.
 #' @template args
 #' @template moreargs
 #' @template cursor_args


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
Sending both parameters results in a cryptic error from CrossRef.  I spent a while trying to establish the cause; listing it in the docs might help other users to avoid this pitfall.


## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->
cr_works(dois='10.26879/775', query='Depth related')

> Warning message:
> 400: This route does not support query - (10.26879/775) 
<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
