### PR TITLE
Add a (single-session) cache to cr_cn

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     miniUI,
     stringr,
     DT,
-    stats
+    stats,
+    rlang
 Suggests:
     roxygen2 (>= 7.1.0),
     testthat,

--- a/R/cache.R
+++ b/R/cache.R
@@ -1,0 +1,4 @@
+# Create cache environment when package is loaded
+cr_cache_env <- rlang::new_environment()
+
+

--- a/man/cr_cn.Rd
+++ b/man/cr_cn.Rd
@@ -12,6 +12,7 @@ cr_cn(
   raw = FALSE,
   .progress = "none",
   url = NULL,
+  cache = FALSE,
   ...
 )
 }
@@ -43,6 +44,9 @@ non-boolean is coerced to \code{FALSE}.}
 
 \item{url}{(character) Base URL for the content negotiation request.
 Default: "https://doi.org"}
+
+\item{cache}{(logical) Should requests be cached and/or retrieved from
+the cache? Note that the cache only persists while the package is loaded.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{verb-GET}}}
 }
@@ -131,9 +135,13 @@ cr_cn("10.1890/0012-9615(1999)069[0569:EDILSA]2.0.CO;2")
 # Use a different base url
 cr_cn("10.1126/science.169.3946.635", "text", url = "http://dx.doi.org")
 cr_cn("10.1126/science.169.3946.635", "text", "heredity", url = "http://dx.doi.org")
-cr_cn("10.5284/1011335", url = "https://citation.crosscite.org/format", 
+cr_cn("10.5284/1011335", url = "https://citation.crosscite.org/format",
    style = "oikos")
-cr_cn("10.5284/1011335", url = "https://citation.crosscite.org/format", 
+cr_cn("10.5284/1011335", url = "https://citation.crosscite.org/format",
    style = "plant-cell-and-environment")
+
+# A temporary cache can be used to avoid sending the same request repeatedly
+# within the same R session.
+cr_cn("10.5284/1011335", cache = TRUE)
 }
 }

--- a/tests/testthat/test-cr_cn.R
+++ b/tests/testthat/test-cr_cn.R
@@ -7,7 +7,7 @@ test_that("cr_cn citeproc-json", {
     expect_match(b$`container-title`, "Science")
   })
 })
-  
+
 test_that("cr_cn bibtex", {
   skip_if_not_installed("bibtex")
   vcr::use_cassette("cr_cn_bibentry", {
@@ -88,3 +88,18 @@ test_that("cr_cn works with different URLs", {
     )
   }, preserve_exact_body_bytes = TRUE, match_requests_on = c("method"))
 })
+
+test_that("cr_cn cache works", {
+  vcr::use_cassette("cr_cn_cache", {
+    # reset cache
+    rm(list = ls(cr_cache_env), envir = cr_cache_env)
+    t1 <- system.time(b1 <- cr_cn(dois = "10.1126/science.169.3946.635", format = "citeproc-json", cache = TRUE))
+    t2 <- system.time(b2 <- cr_cn(dois = "10.1126/science.169.3946.635", format = "citeproc-json", cache = TRUE))
+    # compare timing to ensure that caching actually happened
+    expect_gt(t1[3], t2[3])
+    expect_identical(b1, b2)
+    expect_is(b1, "list")
+    expect_match(b1$`container-title`, "Science")
+  })
+})
+


### PR DESCRIPTION
## Description
This adds an option to use a cache for `cr_cn` (and an approach that could easily be generalised to other request functions). The cache only persists for a single session - yet at least in my use case, that is the most relevant constraint to ensure that (e.g.) functions that fail half-way do not need to repeat requests.

It notionally adds a new dependency (`rlang`) but that is already required by `dplyr` etc anyway.

## Related Issue
This does not go quite as far as #185 but might be a light-weight first step?

## Example
 cr_cn(dois = "10.1126/science.169.3946.635", format = "citeproc-json", cache = TRUE)
# behaviour unchanged on first call, much faster from second call onward.