### PR TITLE
Further cache support (cr_abstract and cr_works)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,10 @@
+rcrossref 1.2.1
+===============
+
+### MINOR IMPROVEMENTS
+* Requests can now be cached (for a single session) with `cr_works`, `cr_abstract` and `cr_cn` by setting `cache = TRUE`
+
+
 rcrossref 1.2.0
 ===============
 

--- a/R/cr_abstract.R
+++ b/R/cr_abstract.R
@@ -1,44 +1,59 @@
 #' Get abstract
-#' 
+#'
 #' @export
 #' @param doi (character) a DOI, required.
+#' @param cache (logical) Should requests be cached and/or retrieved from
+#' the cache? Note that the cache only persists while the package is loaded.
 #' @param ... Named parameters passed on to \code{\link[crul]{HttpClient}}
 #' @examples \dontrun{
 #' # abstract found
 #' cr_abstract('10.1109/TASC.2010.2088091')
 #' cr_abstract("10.1175//2572.1")
 #' cr_abstract("10.1182/blood.v16.1.1039.1039")
-#' 
+#'
 #' # doi not found
 #' # cr_abstract(doi = '10.5284/1011335')
-#' 
+#'
 #' # abstract not found, throws error
 #' # cr_abstract(doi = '10.1126/science.169.3946.635')
-#' 
+#'
 #' # a random DOI
 #' # cr_abstract(cr_r(1))
 #' }
-cr_abstract <- function(doi, ...) {
-  url <- paste0('https://api.crossref.org/works/', doi, '/transform/application/vnd.crossref.unixsd+xml')
-  cli <- crul::HttpClient$new(
-    url = url,
-    opts = list(followlocation = 1),
-    headers = list(
-      `User-Agent` = rcrossref_ua(),
-      `X-USER-AGENT` = rcrossref_ua()
+cr_abstract <- function(doi, cache = FALSE, ...) {
+  if (cache == TRUE) {
+    req <- paste("cr_abstract", doi,
+      paste(unlist(list(...)), sep = "__"),
+      sep = "__"
     )
-  )
-  res <- cli$get(...)
-  res$raise_for_status()
-  txt <- res$parse("UTF-8")
-  xml <- tryCatch(read_xml(txt), error = function(e) e)
-  if (inherits(xml, "error")) {
-    stop(doi, " not found ", call. = FALSE)
+
+    rlang::env_cache(
+      env = cr_cache_env, nm = req,
+      default = cr_abstract(doi, cache = FALSE, ...)
+    )
+  } else {
+    url <- paste0("https://api.crossref.org/works/", doi, "/transform/application/vnd.crossref.unixsd+xml")
+    cli <- crul::HttpClient$new(
+      url = url,
+      opts = list(followlocation = 1),
+      headers = list(
+        `User-Agent` = rcrossref_ua(),
+        `X-USER-AGENT` = rcrossref_ua()
+      )
+    )
+    res <- cli$get(...)
+    res$raise_for_status()
+    txt <- res$parse("UTF-8")
+    xml <- tryCatch(read_xml(txt), error = function(e) e)
+    if (inherits(xml, "error")) {
+      stop(doi, " not found ", call. = FALSE)
+    }
+    tt <- tryCatch(xml_find_first(xml, "//jats:abstract"),
+      warning = function(w) w
+    )
+    if (inherits(tt, "warning")) {
+      stop("no abstract found for ", doi, call. = FALSE)
+    }
+    xml_text(tt)
   }
-  tt <- tryCatch(xml_find_first(xml, "//jats:abstract"), 
-                 warning = function(w) w)
-  if (inherits(tt, "warning")) {
-    stop("no abstract found for ", doi, call. = FALSE)
-  }
-  xml_text(tt)
 }

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -215,7 +215,7 @@ cr_works <- function(
       sep = "__"
     )
 
-    if (object.size(req) > 10000) {
+    if (utils::object.size(req) > 10000) {
       warning("Request call is too large to be cached (likely because many DOIs at once are requested). Request will be executed with cache = FALSE. Split into multiple calls to cache.")
       works_do(
         dois, query, filter, offset, limit, sample,

--- a/R/cr_works.R
+++ b/R/cr_works.R
@@ -214,6 +214,16 @@ cr_works <- function(
       paste(unlist(list(...)), sep = "__"),
       sep = "__"
     )
+
+    if (object.size(req) > 10000) {
+      warning("Request call is too large to be cached (likely because many DOIs at once are requested). Request will be executed with cache = FALSE. Split into multiple calls to cache.")
+      works_do(
+        dois, query, filter, offset, limit, sample,
+        sort, order, facet, cursor, cursor_max, .progress, flq, select, async,
+        ...
+      )
+    }
+
     rlang::env_cache(
       env = cr_cache_env, nm = req,
       default = works_do(dois, query, filter, offset, limit, sample,

--- a/man/cr_abstract.Rd
+++ b/man/cr_abstract.Rd
@@ -4,10 +4,13 @@
 \alias{cr_abstract}
 \title{Get abstract}
 \usage{
-cr_abstract(doi, ...)
+cr_abstract(doi, cache = FALSE, ...)
 }
 \arguments{
 \item{doi}{(character) a DOI, required.}
+
+\item{cache}{(logical) Should requests be cached and/or retrieved from
+the cache? Note that the cache only persists while the package is loaded.}
 
 \item{...}{Named parameters passed on to \code{\link[crul]{HttpClient}}}
 }

--- a/man/cr_journals.Rd
+++ b/man/cr_journals.Rd
@@ -226,7 +226,7 @@ cr_journals_("2167-8359", works = TRUE, cursor = "*",
 cr_journals("2167-8359", works = TRUE, flq = c(`query.author` = 'Jane'))
 
 # select only certain fields to return
-res <- cr_journals('2167-8359', works = TRUE, 
+res <- cr_journals('2167-8359', works = TRUE,
   select = c('DOI', 'title'))
 names(res$data)
 }

--- a/man/cr_works.Rd
+++ b/man/cr_works.Rd
@@ -21,6 +21,7 @@ cr_works(
   flq = NULL,
   select = NULL,
   async = FALSE,
+  cache = FALSE,
   ...
 )
 
@@ -137,6 +138,9 @@ are returned)}
 
 \item{async}{(logical) use async HTTP requests. Default: \code{FALSE}}
 
+\item{cache}{(logical) Should requests be cached and/or retrieved from
+the cache? Note that the cache only persists while the package is loaded.}
+
 \item{...}{Named parameters passed on to \code{\link[crul]{verb-GET}}}
 
 \item{parse}{(logical) Whether to output json \code{FALSE} or parse to
@@ -246,7 +250,7 @@ cr_works(query="NSF", cursor = "*", cursor_max = 300, limit = 100)
 cr_works(query="NSF", cursor = "*", cursor_max = 300, limit = 100,
    facet = TRUE)
 ## with optional progress bar
-x <- cr_works(query="NSF", cursor = "*", cursor_max = 1200, limit = 200, 
+x <- cr_works(query="NSF", cursor = "*", cursor_max = 1200, limit = 200,
   .progress = TRUE)
 
 # Low level function - does no parsing to data.frame, get json or a list

--- a/tests/testthat/test-cr_works.R
+++ b/tests/testthat/test-cr_works.R
@@ -230,7 +230,7 @@ test_that("cr_works fails well: arguments that dont require http requests", {
   expect_error(cr_works(offset = 'foo'), "offset value illegal")
 
   expect_error(cr_works(sample = 'foo'), "sample value illegal")
-  
+
   expect_error(cr_works(async = 5), "is not TRUE")
 })
 
@@ -240,4 +240,29 @@ test_that("content domain parsing fix", {
   vcr::use_cassette("cr_works_no_content_domain_fail", {
     expect_is(cr_works(dois = "10.7287/peerj.3819v0.1/reviews/2"), "list")
   })
+})
+
+test_that("cr_works cache works", {
+  #vcr::use_cassette("cr_works_cache", { # Error with HTTP request here, but apart from that, test works
+    ## With query
+    # reset cache
+    rm(list = ls(cr_cache_env), envir = cr_cache_env)
+    t1 <- system.time(b1 <- cr_works(query="NSF", cache = TRUE))
+    t2 <- system.time(b2 <- cr_works(query="NSF", cache = TRUE))
+    # compare timing to ensure that caching actually happened
+    expect_gt(t1[3], t2[3])
+    expect_identical(b1, b2)
+    expect_is(b1, "list")
+
+    ## With multiple DOIs
+    # reset cache
+    rm(list = ls(cr_cache_env), envir = cr_cache_env)
+    t1 <- system.time(b1 <- cr_works(dois = c("10.1037/0022-3514.45.2.357", "10.1002/9781118719244"), cache = TRUE))
+    t2 <- system.time(b2 <- cr_works(dois = c("10.1037/0022-3514.45.2.357", "10.1002/9781118719244"), cache = TRUE))
+    # compare timing to ensure that caching actually happened
+    expect_gt(t1[3], t2[3])
+    expect_identical(b1, b2)
+    expect_is(b1, "list")
+    expect_match(b1$data$`container.title`[1], "Journal of Personality and Social Psychology")
+ # })
 })


### PR DESCRIPTION
In line with the addition to `cr_cn()` in #237, I now added a `cache = TRUE` option to `cr_works` and `cr_abstract`. 

One limitation: In `cr_works`, it is based on full requests rather than individual DOIs, which is not ideal but was easier to implement and should usually be sufficient. If too many DOIs are requested at once, however, the request cannot be cached, so an informative warning is provided and the request is executed without cache.

There was an issue with `vcr` when implementing the test, and I did not understand the error - it works without `vcr` which seems to be what matters but I refrained from writing further tests for now, happy to continue on that if you have a suggestion for how to make vcr play nice.